### PR TITLE
chore: add supabase types and improve typings

### DIFF
--- a/src/components/ForecastSummary.tsx
+++ b/src/components/ForecastSummary.tsx
@@ -1,5 +1,16 @@
 import { useState, useEffect } from 'react';
-import { ArrowLeft, TrendingUp, DollarSign, Minus, Calculator, Calendar, Filter, Truck, FileText, Navigation } from 'lucide-react';
+import {
+  ArrowLeft,
+  TrendingUp,
+  DollarSign,
+  Minus,
+  Calculator,
+  Calendar,
+  Filter,
+  Truck,
+  FileText,
+  Navigation,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -10,33 +21,12 @@ import { formatCurrency } from '@/lib/utils';
 import LoadCard from './LoadCard';
 import { useAuth } from '@/hooks/useAuth';
 import { getUserWeekStart, getUserWeekEnd, getWeekStartForPeriod, getWeekEndForPeriod } from '../lib/weeklyPeriodUtils';
-
-interface Load {
-  id: string;
-  rate: number;
-  companyDeduction: number;
-  driverPay: number;
-  locationFrom: string;
-  locationTo: string;
-  pickupDate?: string;
-  deliveryDate?: string;
-  dateAdded: string;
-  weekPeriod: string;
-}
-
-interface Deduction {
-  id: string;
-  type: string;
-  amount: number;
-  isFixed: boolean;
-  isCustomType?: boolean;
-  dateAdded?: string;
-}
+import { Load, Deduction, UserProfile } from '@/types/LoadReports';
 
 interface ForecastSummaryProps {
   onBack: () => void;
   deductions: Deduction[];
-  userProfile: any; // Add this line
+  userProfile: UserProfile | null;
 }
 
 const ForecastSummary = ({ onBack, deductions, userProfile }: ForecastSummaryProps) => {

--- a/src/components/LoadReportsHeader.tsx
+++ b/src/components/LoadReportsHeader.tsx
@@ -2,12 +2,13 @@ import { ArrowLeft, Calendar } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { format } from 'date-fns';
 import { getWeeklyPeriodDisplay } from '@/lib/loadReportsUtils';
+import { UserProfile } from '@/types/LoadReports';
 
 interface LoadReportsHeaderProps {
   onBack: () => void;
   weekStart: Date;
   weekEnd: Date;
-  userProfile: any;
+  userProfile: UserProfile;
   onNavigateWeek: (direction: 'prev' | 'next') => void;
 }
 

--- a/src/hooks/useDeductionsManager.ts
+++ b/src/hooks/useDeductionsManager.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { User } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 import { ExtraDeduction } from '@/types/LoadReports';
 
@@ -11,7 +12,7 @@ import { ExtraDeduction } from '@/types/LoadReports';
  * @param user      – объект текущего пользователя Supabase
  * @param weekStart – дата начала недели (Sunday 00:00)
  */
-export const useDeductionsManager = (user: any, weekStart: Date) => {
+export const useDeductionsManager = (user: User | null, weekStart: Date) => {
   /** ---------- State ---------- */
   const [weeklyDeductions, setWeeklyDeductions] = useState<Record<string, string>>({});
   const [extraDeductionTypes, setExtraDeductionTypes] = useState<ExtraDeduction[]>([]);
@@ -49,8 +50,8 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
         });
         setWeeklyDeductions(map);
       }
-    } catch (err: any) {
-      if (err.name !== 'AbortError') console.error('fetchWeeklyDeductions:', err);
+    } catch (err: unknown) {
+      if ((err as Error).name !== 'AbortError') console.error('fetchWeeklyDeductions:', err);
     } finally {
       setIsLoading(false);
     }
@@ -82,8 +83,8 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
         }));
         setExtraDeductionTypes(extras);
       }
-    } catch (err: any) {
-      if (err.name !== 'AbortError') console.error('fetchExtraDeductions:', err);
+    } catch (err: unknown) {
+      if ((err as Error).name !== 'AbortError') console.error('fetchExtraDeductions:', err);
     } finally {
       setIsLoading(false);
     }

--- a/src/hooks/useLoadReports.ts
+++ b/src/hooks/useLoadReports.ts
@@ -1,8 +1,16 @@
 import { useState, useEffect } from 'react';
 import { format, addWeeks, subWeeks, isWithinInterval, parseISO } from 'date-fns';
+import { User } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 import { getUserWeekStart, getUserWeekEnd } from '@/lib/weeklyPeriodUtils';
-import { Load, NewLoad, WeeklyMileage, ExtraDeduction } from '@/types/LoadReports';
+import {
+  Load,
+  NewLoad,
+  WeeklyMileage,
+  ExtraDeduction,
+  Deduction,
+  UserProfile,
+} from '@/types/LoadReports';
 
 // Helper function to format dates without timezone issues
 const formatDateForDB = (date: Date): string => {
@@ -12,7 +20,11 @@ const formatDateForDB = (date: Date): string => {
   return `${year}-${month}-${day}`;
 };
 
-export const useLoadReports = (user: any, userProfile: any, deductions: any[]) => {
+export const useLoadReports = (
+  user: User | null,
+  userProfile: UserProfile | null,
+  deductions: Deduction[],
+) => {
   const [currentWeek, setCurrentWeek] = useState(getUserWeekStart(new Date(), userProfile));
   const [allDeductionTypes, setAllDeductionTypes] = useState<string[]>([]);
   const [weeklyDeductions, setWeeklyDeductions] = useState<Record<string, string>>({});

--- a/src/hooks/useMileageManager.ts
+++ b/src/hooks/useMileageManager.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
+import { User } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 import { WeeklyMileage } from '@/types/LoadReports';
 
-export const useMileageManager = (user: any, weekStart: Date) => {
+export const useMileageManager = (user: User | null, weekStart: Date) => {
   const [weeklyMileage, setWeeklyMileage] = useState<WeeklyMileage>({
     startMileage: '',
     endMileage: '',

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -18,6 +18,8 @@ export type Database = {
           id: string
           phone: string | null
           updated_at: string
+          weekly_period: string | null
+          weekly_period_updated_at: string | null
         }
         Insert: {
           company_deduction: number
@@ -27,6 +29,8 @@ export type Database = {
           id: string
           phone?: string | null
           updated_at?: string
+          weekly_period?: string | null
+          weekly_period_updated_at?: string | null
         }
         Update: {
           company_deduction?: number
@@ -36,6 +40,197 @@ export type Database = {
           id?: string
           phone?: string | null
           updated_at?: string
+          weekly_period?: string | null
+          weekly_period_updated_at?: string | null
+        }
+        Relationships: []
+      }
+      load_reports: {
+        Row: {
+          id: string
+          user_id: string
+          rate: number
+          company_deduction: number
+          driver_pay: number
+          location_from: string
+          location_to: string
+          pickup_date: string | null
+          delivery_date: string | null
+          date_added: string
+          week_period: string
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          rate: number
+          company_deduction: number
+          driver_pay: number
+          location_from: string
+          location_to: string
+          pickup_date?: string | null
+          delivery_date?: string | null
+          date_added: string
+          week_period: string
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          rate?: number
+          company_deduction?: number
+          driver_pay?: number
+          location_from?: string
+          location_to?: string
+          pickup_date?: string | null
+          delivery_date?: string | null
+          date_added?: string
+          week_period?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      deductions: {
+        Row: {
+          id: string
+          user_id: string
+          type: string
+          amount: number
+          is_fixed: boolean
+          is_custom_type: boolean
+          date_added: string
+          week_period: string | null
+          load_report_id: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          type: string
+          amount: number
+          is_fixed?: boolean
+          is_custom_type?: boolean
+          date_added?: string
+          week_period?: string | null
+          load_report_id?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          type?: string
+          amount?: number
+          is_fixed?: boolean
+          is_custom_type?: boolean
+          date_added?: string
+          week_period?: string | null
+          load_report_id?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      weekly_deductions: {
+        Row: {
+          id: number
+          user_id: string
+          week_start: string
+          deduction_type: string
+          amount: number
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: number
+          user_id: string
+          week_start: string
+          deduction_type: string
+          amount: number
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: number
+          user_id?: string
+          week_start?: string
+          deduction_type?: string
+          amount?: number
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      weekly_extra_deductions: {
+        Row: {
+          id: number
+          user_id: string
+          week_start: string
+          name: string | null
+          deduction_type: string | null
+          amount: number
+          date_added: string | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: number
+          user_id: string
+          week_start: string
+          name?: string | null
+          deduction_type?: string | null
+          amount: number
+          date_added?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: number
+          user_id?: string
+          week_start?: string
+          name?: string | null
+          deduction_type?: string | null
+          amount?: number
+          date_added?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      weekly_mileage: {
+        Row: {
+          id: number
+          user_id: string
+          week_start: string
+          start_mileage: number | null
+          end_mileage: number | null
+          total_miles: number | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: number
+          user_id: string
+          week_start: string
+          start_mileage?: number | null
+          end_mileage?: number | null
+          total_miles?: number | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: number
+          user_id?: string
+          week_start?: string
+          start_mileage?: number | null
+          end_mileage?: number | null
+          total_miles?: number | null
+          created_at?: string | null
+          updated_at?: string | null
         }
         Relationships: []
       }
@@ -165,3 +360,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+

--- a/src/lib/loadReportsUtils.ts
+++ b/src/lib/loadReportsUtils.ts
@@ -1,17 +1,22 @@
+import { Deduction } from '@/types/LoadReports';
+
 export const getWeeklyPeriodDisplay = (weeklyPeriod: string) => {
   const periodMap = {
-    'sunday': 'SUNDAY_TO_SATURDAY',
-    'monday': 'MONDAY_TO_SUNDAY',
-    'tuesday': 'TUESDAY_TO_MONDAY',
-    'wednesday': 'WEDNESDAY_TO_TUESDAY',
-    'thursday': 'THURSDAY_TO_WEDNESDAY',
-    'friday': 'FRIDAY_TO_THURSDAY',
-    'saturday': 'SATURDAY_TO_FRIDAY'
-  };
-  return periodMap[weeklyPeriod] || 'SUNDAY_TO_SATURDAY';
+    sunday: 'SUNDAY_TO_SATURDAY',
+    monday: 'MONDAY_TO_SUNDAY',
+    tuesday: 'TUESDAY_TO_MONDAY',
+    wednesday: 'WEDNESDAY_TO_TUESDAY',
+    thursday: 'THURSDAY_TO_WEDNESDAY',
+    friday: 'FRIDAY_TO_THURSDAY',
+    saturday: 'SATURDAY_TO_FRIDAY',
+  } as const;
+  return periodMap[weeklyPeriod as keyof typeof periodMap] || 'SUNDAY_TO_SATURDAY';
 };
 
-export const calculateFixedDeductionsForWeek = (deductions: any[], weekStartDate: Date) => {
+export const calculateFixedDeductionsForWeek = (
+  deductions: Deduction[],
+  weekStartDate: Date,
+) => {
   if (!deductions) return 0;
   
   const weekStartString = weekStartDate.toISOString().split('T')[0];

--- a/src/lib/weeklyPeriodUtils.ts
+++ b/src/lib/weeklyPeriodUtils.ts
@@ -1,4 +1,5 @@
 import { startOfWeek, endOfWeek, isAfter, isBefore, startOfDay } from 'date-fns';
+import { UserProfile } from '@/types/LoadReports';
 
 // Map weekly period strings to weekStartsOn values
 const WEEKLY_PERIOD_MAP = {
@@ -16,7 +17,7 @@ export const getWeekStartsOn = (weeklyPeriod: string): number => {
 };
 
 // Determine which weekly period to use for a specific date
-export const getWeeklyPeriodForDate = (date: Date, userProfile: any): string => {
+export const getWeeklyPeriodForDate = (date: Date, userProfile: UserProfile | null): string => {
   const { weeklyPeriod, weeklyPeriodUpdatedAt } = userProfile || {};
   
   // If no update timestamp, use current weekly period
@@ -41,13 +42,13 @@ export const getWeeklyPeriodForDate = (date: Date, userProfile: any): string => 
   return weeklyPeriod || 'sunday';
 };
 
-export const getUserWeekStart = (date: Date, userProfile: any): Date => {
+export const getUserWeekStart = (date: Date, userProfile: UserProfile | null): Date => {
   const weeklyPeriod = getWeeklyPeriodForDate(date, userProfile);
   const weekStartsOn = getWeekStartsOn(weeklyPeriod);
   return startOfWeek(date, { weekStartsOn });
 };
 
-export const getUserWeekEnd = (date: Date, userProfile: any): Date => {
+export const getUserWeekEnd = (date: Date, userProfile: UserProfile | null): Date => {
   const weeklyPeriod = getWeeklyPeriodForDate(date, userProfile);
   const weekStartsOn = getWeekStartsOn(weeklyPeriod);
   return endOfWeek(date, { weekStartsOn });

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,14 +11,15 @@ import Deductions from '@/components/Deductions';
 import ForecastSummary from '@/components/ForecastSummary';
 import SettingsPanel from '@/components/SettingsPanel';
 import PersonalExpenses from '@/components/PersonalExpenses';
+import { Deduction, UserProfile } from '@/types/LoadReports';
 
 const Index = () => {
   const { user, loading, signOut } = useAuth();
   const [currentView, setCurrentView] = useState('dashboard');
   const [showRegistration, setShowRegistration] = useState(false);
-  const [userProfile, setUserProfile] = useState(null);
+  const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [loads, setLoads] = useState([]);
-  const [deductions, setDeductions] = useState([]);
+  const [deductions, setDeductions] = useState<Deduction[]>([]);
 
   useEffect(() => {
     if (user) {

--- a/src/types/LoadReports.ts
+++ b/src/types/LoadReports.ts
@@ -1,3 +1,6 @@
+import { User } from '@supabase/supabase-js';
+import { Tables } from '@/integrations/supabase/types';
+
 export interface Load {
   id: string;
   rate: number;
@@ -11,11 +14,30 @@ export interface Load {
   weekPeriod: string;
 }
 
+export interface UserProfile {
+  name: string;
+  phone: string | null;
+  email: string | null;
+  driverType: string;
+  companyDeduction: number;
+  weeklyPeriod: string;
+  weeklyPeriodUpdatedAt?: string | null;
+}
+
+export type Deduction = {
+  id: Tables<'deductions'>['Row']['id'];
+  type: Tables<'deductions'>['Row']['type'];
+  amount: Tables<'deductions'>['Row']['amount'];
+  isFixed: Tables<'deductions'>['Row']['is_fixed'];
+  isCustomType: Tables<'deductions'>['Row']['is_custom_type'];
+  dateAdded: Tables<'deductions'>['Row']['date_added'];
+};
+
 export interface LoadReportsProps {
   onBack: () => void;
-  user: any;
-  userProfile: any;
-  deductions: any[];
+  user: User;
+  userProfile: UserProfile | null;
+  deductions: Deduction[];
 }
 
 export interface WeeklyMileage {


### PR DESCRIPTION
## Summary
- regenerate Supabase types to cover load reports and deductions tables
- replace `any` usage with typed interfaces for load reports, mileage, and deductions
- add shared Deduction and UserProfile interfaces

## Testing
- `npm run lint`
- `VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c1d684a14833391d3c940ac60fe6e