### PR TITLE
Include userProfile in PersonalExpenses

### DIFF
--- a/src/components/PersonalExpenses.tsx
+++ b/src/components/PersonalExpenses.tsx
@@ -32,6 +32,7 @@ interface Expense {
 
 interface PersonalExpensesProps {
   onBack: () => void;
+  userProfile?: any;
 }
 
 const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile }) => {
@@ -54,34 +55,35 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
   // Calculate date range based on period filter
   const getDateRange = () => {
     const today = new Date();
+    const profile = userProfile || {};
     let startDate: Date;
     let endDate: Date;
 
     switch (periodFilter) {
       case 'last2':
-        startDate = getUserWeekStart(subWeeks(today, 1), userProfile);
-        endDate = getUserWeekEnd(today, userProfile);
+        startDate = getUserWeekStart(subWeeks(today, 1), profile);
+        endDate = getUserWeekEnd(today, profile);
         break;
       case 'last3':
-        startDate = getUserWeekStart(subWeeks(today, 2), userProfile);
-        endDate = getUserWeekEnd(today, userProfile);
+        startDate = getUserWeekStart(subWeeks(today, 2), profile);
+        endDate = getUserWeekEnd(today, profile);
         break;
       case 'last4':
-        startDate = getUserWeekStart(subWeeks(today, 3), userProfile);
-        endDate = getUserWeekEnd(today, userProfile);
+        startDate = getUserWeekStart(subWeeks(today, 3), profile);
+        endDate = getUserWeekEnd(today, profile);
         break;
       case 'custom':
         if (customDateRange?.from && customDateRange?.to) {
           startDate = customDateRange.from;
           endDate = customDateRange.to;
         } else {
-          startDate = getUserWeekStart(today, userProfile);
-          endDate = getUserWeekEnd(today, userProfile);
+          startDate = getUserWeekStart(today, profile);
+          endDate = getUserWeekEnd(today, profile);
         }
         break;
       default:
-        startDate = getUserWeekStart(subWeeks(today, 1), userProfile);
-        endDate = getUserWeekEnd(today, userProfile);
+        startDate = getUserWeekStart(subWeeks(today, 1), profile);
+        endDate = getUserWeekEnd(today, profile);
     }
 
     return { startDate, endDate };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -147,8 +147,9 @@ const Index = () => {
         );
       case 'expenses':
         return (
-          <PersonalExpenses 
+          <PersonalExpenses
             onBack={() => setCurrentView('dashboard')}
+            userProfile={userProfile}
           />
         );
       case 'settings':


### PR DESCRIPTION
## Summary
- extend PersonalExpenses props to accept optional userProfile data
- guard date range calculations when no profile is available
- forward userProfile from Index page to PersonalExpenses component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c1f8fdfac833393fa5407fa6764c0