### PR TITLE
refactor: toast error handling for supabase

### DIFF
--- a/src/components/Deductions.tsx
+++ b/src/components/Deductions.tsx
@@ -21,9 +21,11 @@ import { supabase } from '@/integrations/supabase/client';
 import DeductionsSummary from './DeductionsSummary';
 import { formatCurrency } from '@/lib/utils';
 import { startOfWeek } from 'date-fns';
+import { useToast } from '@/hooks/use-toast';
 
 const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
   const { user } = useAuth();
+  const { toast } = useToast();
   const [fixedDeductions, setFixedDeductions] = useState({});
   const [newDeductionType, setNewDeductionType] = useState('');
   const [customDeductionTypes, setCustomDeductionTypes] = useState([]);
@@ -49,7 +51,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
         .order('created_at', { ascending: false });
   
       if (error) {
-        console.error('Error fetching deductions:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to fetch deductions. Please try again.'
+        });
         return;
       }
   
@@ -65,7 +71,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
         setDeductions(mappedDeductions);
       }
     } catch (error) {
-      console.error('Error fetching deductions:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to fetch deductions. Please try again.'
+      });
     }
   };
 
@@ -94,7 +104,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
             }));
           }
         } catch (error) {
-          console.error('Error updating fixed deduction:', error);
+          toast({
+            variant: 'destructive',
+            title: 'Error',
+            description: 'Failed to update fixed deduction. Please try again.'
+          });
         }
       } else {
         // Just update local state if no database record
@@ -172,7 +186,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
             });
     
           if (error) {
-            console.error('Error creating new deduction version:', error);
+            toast({
+              variant: 'destructive',
+              title: 'Error',
+              description: 'Failed to create new deduction version. Please try again.'
+            });
             return;
           }
         } else {
@@ -189,7 +207,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
             });
     
           if (error) {
-            console.error('Error saving deduction:', error);
+            toast({
+              variant: 'destructive',
+              title: 'Error',
+              description: 'Failed to save deduction. Please try again.'
+            });
             return;
           }
         }
@@ -204,7 +226,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
         }));
         
       } catch (error) {
-        console.error('Error saving deduction:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to save deduction. Please try again.'
+        });
       } finally {
         setLoading(false);
       }
@@ -230,7 +256,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
           .single();
 
         if (error) {
-          console.error('Error adding custom deduction type:', error);
+          toast({
+            variant: 'destructive',
+            title: 'Error',
+            description: 'Failed to add custom deduction type. Please try again.'
+          });
           return;
         }
 
@@ -250,7 +280,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
         setNewDeductionType('');
         
       } catch (error) {
-        console.error('Error adding custom deduction type:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to add custom deduction type. Please try again.'
+        });
       } finally {
         setLoading(false);
       }
@@ -268,14 +302,22 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
         .eq('user_id', user.id);
 
       if (error) {
-        console.error('Error deleting deduction:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to delete deduction. Please try again.'
+        });
         return;
       }
 
       // Update local state
       setDeductions(prev => prev.filter(deduction => deduction.id !== id));
     } catch (error) {
-      console.error('Error deleting deduction:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to delete deduction. Please try again.'
+      });
     }
   };
 
@@ -291,7 +333,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
         .single();
 
       if (error && error.code !== 'PGRST116') { // PGRST116 is "not found" error
-        console.error('Error fetching removed predefined types:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to fetch removed predefined types. Please try again.'
+        });
         return;
       }
 
@@ -299,7 +345,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
         setRemovedPredefinedTypes(data.removed_predefined_types);
       }
     } catch (error) {
-      console.error('Error fetching removed predefined types:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to fetch removed predefined types. Please try again.'
+      });
     }
   };
 
@@ -319,7 +369,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
         .single();
 
       if (fetchError && fetchError.code !== 'PGRST116') {
-        console.error('Error checking user preferences:', fetchError);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to check user preferences. Please try again.'
+        });
         return;
       }
 
@@ -331,7 +385,11 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
           .eq('user_id', user.id);
 
         if (error) {
-          console.error('Error updating removed predefined types:', error);
+          toast({
+            variant: 'destructive',
+            title: 'Error',
+            description: 'Failed to update removed predefined types. Please try again.'
+          });
         }
       } else {
         // Create new record
@@ -343,11 +401,19 @@ const Deductions = ({ onBack, deductions, setDeductions }: DeductionsProps) => {
           });
 
         if (error) {
-          console.error('Error saving removed predefined types:', error);
+          toast({
+            variant: 'destructive',
+            title: 'Error',
+            description: 'Failed to save removed predefined types. Please try again.'
+          });
         }
       }
     } catch (error) {
-      console.error('Error persisting removed predefined types:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to persist removed predefined types. Please try again.'
+      });
     }
   };
 

--- a/src/components/ForecastSummary.tsx
+++ b/src/components/ForecastSummary.tsx
@@ -10,6 +10,7 @@ import { formatCurrency } from '@/lib/utils';
 import LoadCard from './LoadCard';
 import { useAuth } from '@/hooks/useAuth';
 import { getUserWeekStart, getUserWeekEnd, getWeekStartForPeriod, getWeekEndForPeriod } from '../lib/weeklyPeriodUtils';
+import { useToast } from '@/hooks/use-toast';
 
 interface Load {
   id: string;
@@ -41,6 +42,7 @@ interface ForecastSummaryProps {
 
 const ForecastSummary = ({ onBack, deductions, userProfile }: ForecastSummaryProps) => {
   const { user } = useAuth();
+  const { toast } = useToast();
   const [periodFilter, setPeriodFilter] = useState('last2');
   const [customDateRange, setCustomDateRange] = useState<{from: Date, to: Date} | undefined>();
   const [loads, setLoads] = useState<Load[]>([]);
@@ -114,7 +116,11 @@ const ForecastSummary = ({ onBack, deductions, userProfile }: ForecastSummaryPro
         .order('date_added', { ascending: false });
 
       if (error) {
-        console.error('Error fetching loads:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to fetch loads. Please try again.'
+        });
         return;
       }
 
@@ -135,7 +141,11 @@ const ForecastSummary = ({ onBack, deductions, userProfile }: ForecastSummaryPro
         setLoads(formattedLoads);
       }
     } catch (error) {
-      console.error('Error fetching loads:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to fetch loads. Please try again.'
+      });
     } finally {
       setLoading(false);
     }
@@ -162,7 +172,11 @@ const ForecastSummary = ({ onBack, deductions, userProfile }: ForecastSummaryPro
         .in('week_start', weeks);
 
       if (error) {
-        console.error('Error fetching weekly deductions:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to fetch weekly deductions. Please try again.'
+        });
         return;
       }
 
@@ -177,7 +191,11 @@ const ForecastSummary = ({ onBack, deductions, userProfile }: ForecastSummaryPro
         setWeeklyDeductions(deductionsMap);
       }
     } catch (error) {
-      console.error('Error fetching weekly deductions:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to fetch weekly deductions. Please try again.'
+      });
     }
   };
 
@@ -202,7 +220,11 @@ const ForecastSummary = ({ onBack, deductions, userProfile }: ForecastSummaryPro
         .in('week_start', weeks);
 
       if (error) {
-        console.error('Error fetching extra deductions:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to fetch extra deductions. Please try again.'
+        });
         return;
       }
 
@@ -221,7 +243,11 @@ const ForecastSummary = ({ onBack, deductions, userProfile }: ForecastSummaryPro
         setExtraDeductions(extraMap);
       }
     } catch (error) {
-      console.error('Error fetching extra deductions:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to fetch extra deductions. Please try again.'
+      });
     }
   };
 
@@ -295,7 +321,11 @@ const ForecastSummary = ({ onBack, deductions, userProfile }: ForecastSummaryPro
         .in('week_start', weeks);
 
       if (error) {
-        console.error('Error fetching weekly mileage:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to fetch weekly mileage. Please try again.'
+        });
         return;
       }
 
@@ -311,7 +341,11 @@ const ForecastSummary = ({ onBack, deductions, userProfile }: ForecastSummaryPro
         setWeeklyMileageData(mileageMap);
       }
     } catch (error) {
-      console.error('Error fetching weekly mileage:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to fetch weekly mileage. Please try again.'
+      });
     }
   };
 
@@ -340,14 +374,22 @@ const ForecastSummary = ({ onBack, deductions, userProfile }: ForecastSummaryPro
         .eq('user_id', user.id);
 
       if (error) {
-        console.error('Error deleting load:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to delete load. Please try again.'
+        });
         return;
       }
 
       // Refresh loads
       fetchLoads();
     } catch (error) {
-      console.error('Error deleting load:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to delete load. Please try again.'
+      });
     }
   };
 

--- a/src/components/PersonalExpenses.tsx
+++ b/src/components/PersonalExpenses.tsx
@@ -127,19 +127,17 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         .eq('user_id', user.id)
         .order('name');
 
-      if (error) {
-        console.error('Error fetching expense types:', error);
-        toast({
-          title: "Error",
-          description: "Failed to load expense types",
-          variant: "destructive"
-        });
-        return;
-      }
+        if (error) {
+          toast({
+            title: "Error",
+            description: "Failed to load expense types",
+            variant: "destructive"
+          });
+          return;
+        }
 
       setExpenseTypes(data || []);
     } catch (error) {
-      console.error('Error fetching expense types:', error);
       toast({
         title: "Error",
         description: "Failed to load expense types",
@@ -162,7 +160,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         .order('date', { ascending: false });
 
       if (error) {
-        console.error('Error fetching expenses:', error);
         toast({
           title: "Error",
           description: "Failed to load expenses",
@@ -173,7 +170,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
 
       setExpenses(data || []);
     } catch (error) {
-      console.error('Error fetching expenses:', error);
       toast({
         title: "Error",
         description: "Failed to load expenses",
@@ -218,7 +214,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         .single();
 
       if (error) {
-        console.error('Error adding expense type:', error);
         toast({
           title: "Error",
           description: "Failed to add expense type",
@@ -234,7 +229,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         description: "Expense type added successfully"
       });
     } catch (error) {
-      console.error('Error adding expense type:', error);
       toast({
         title: "Error",
         description: "Failed to add expense type",
@@ -255,7 +249,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         .eq('user_id', user.id);
 
       if (error) {
-        console.error('Error updating expense type:', error);
         toast({
           title: "Error",
           description: "Failed to update expense type",
@@ -274,7 +267,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         description: "Expense type updated successfully"
       });
     } catch (error) {
-      console.error('Error updating expense type:', error);
       toast({
         title: "Error",
         description: "Failed to update expense type",
@@ -295,7 +287,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         .eq('user_id', user.id);
 
       if (error) {
-        console.error('Error deleting expense type:', error);
         toast({
           title: "Error",
           description: "Failed to delete expense type",
@@ -310,7 +301,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         description: "Expense type deleted successfully"
       });
     } catch (error) {
-      console.error('Error deleting expense type:', error);
       toast({
         title: "Error",
         description: "Failed to delete expense type",
@@ -357,7 +347,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         .single();
 
       if (error) {
-        console.error('Error adding expense:', error);
         toast({
           title: "Error",
           description: "Failed to add expense",
@@ -373,7 +362,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         description: "Expense added successfully"
       });
     } catch (error) {
-      console.error('Error adding expense:', error);
       toast({
         title: "Error",
         description: "Failed to add expense",
@@ -394,7 +382,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         .eq('user_id', user.id);
 
       if (error) {
-        console.error('Error deleting expense:', error);
         toast({
           title: "Error",
           description: "Failed to delete expense",
@@ -409,7 +396,6 @@ const PersonalExpenses: React.FC<PersonalExpensesProps> = ({ onBack, userProfile
         description: "Expense deleted successfully"
       });
     } catch (error) {
-      console.error('Error deleting expense:', error);
       toast({
         title: "Error",
         description: "Failed to delete expense",

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -84,7 +84,6 @@ const SettingsPanel = ({ userProfile, setUserProfile, onBack }) => {
         duration: 3000,
       });
     } catch (error) {
-      console.error('Error saving profile:', error);
       toast({
         title: "Error saving settings",
         description: error.message || "Failed to update profile. Please try again.",
@@ -139,7 +138,6 @@ const SettingsPanel = ({ userProfile, setUserProfile, onBack }) => {
         duration: 3000,
       });
     } catch (error) {
-      console.error('Error exporting data:', error);
       toast({
         title: "Export failed",
         description: "Failed to export data. Please try again.",
@@ -209,7 +207,6 @@ const SettingsPanel = ({ userProfile, setUserProfile, onBack }) => {
           duration: 5000,
         });
       } catch (error) {
-        console.error('Error importing data:', error);
         toast({
           title: "Import failed",
           description: error.message || "Failed to import data. Please check the file format.",
@@ -279,7 +276,6 @@ const SettingsPanel = ({ userProfile, setUserProfile, onBack }) => {
       
       setShowFinalConfirm(false);
     } catch (error) {
-      console.error('Error deleting data:', error);
       toast({
         title: "Delete failed",
         description: error.message || "Failed to delete data. Please try again.",

--- a/src/hooks/useDeductionsManager.ts
+++ b/src/hooks/useDeductionsManager.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { ExtraDeduction } from '@/types/LoadReports';
+import { useToast } from '@/hooks/use-toast';
 
 /**
  * Хук управляет:
@@ -16,6 +17,7 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
   const [weeklyDeductions, setWeeklyDeductions] = useState<Record<string, string>>({});
   const [extraDeductionTypes, setExtraDeductionTypes] = useState<ExtraDeduction[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const { toast } = useToast();
 
   /** ---------- Helpers ---------- */
   const weekStartStr = weekStart.toISOString().slice(0, 10);
@@ -50,7 +52,13 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
         setWeeklyDeductions(map);
       }
     } catch (err: any) {
-      if (err.name !== 'AbortError') console.error('fetchWeeklyDeductions:', err);
+      if (err.name !== 'AbortError') {
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to fetch weekly deductions. Please try again.'
+        });
+      }
     } finally {
       setIsLoading(false);
     }
@@ -83,7 +91,13 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
         setExtraDeductionTypes(extras);
       }
     } catch (err: any) {
-      if (err.name !== 'AbortError') console.error('fetchExtraDeductions:', err);
+      if (err.name !== 'AbortError') {
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to fetch extra deductions. Please try again.'
+        });
+      }
     } finally {
       setIsLoading(false);
     }
@@ -123,7 +137,11 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
           );
       }
     } catch (err) {
-      console.error('saveWeeklyDeduction:', err);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to save weekly deduction. Please try again.'
+      });
     }
   };
 
@@ -165,7 +183,11 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
 
       return true;
     } catch (err) {
-      console.error('saveExtraDeduction:', err);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to save extra deduction. Please try again.'
+      });
       return false;
     }
   };
@@ -180,7 +202,11 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
         .eq('id', parseInt(id))
         .eq('user_id', user.id);
     } catch (err) {
-      console.error('deleteExtraDeduction:', err);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to delete extra deduction. Please try again.'
+      });
     }
   };
 

--- a/src/hooks/useLoadReports.ts
+++ b/src/hooks/useLoadReports.ts
@@ -3,6 +3,7 @@ import { format, addWeeks, subWeeks, isWithinInterval, parseISO } from 'date-fns
 import { supabase } from '@/integrations/supabase/client';
 import { getUserWeekStart, getUserWeekEnd } from '@/lib/weeklyPeriodUtils';
 import { Load, NewLoad, WeeklyMileage, ExtraDeduction } from '@/types/LoadReports';
+import { useToast } from '@/hooks/use-toast';
 
 // Helper function to format dates without timezone issues
 const formatDateForDB = (date: Date): string => {
@@ -37,6 +38,7 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
     endMileage: '',
     totalMiles: 0
   });
+  const { toast } = useToast();
 
   const weekStart = getUserWeekStart(currentWeek, userProfile);
   const weekEnd = getUserWeekEnd(currentWeek, userProfile);
@@ -53,7 +55,11 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
       const uniqueTypes = [...new Set(data.map(d => d.type))];
       setAllDeductionTypes(uniqueTypes);
     } catch (error) {
-      console.error('Error fetching deduction types:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to fetch deduction types. Please try again.'
+      });
     }
   };
 
@@ -68,7 +74,11 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
         .order('date_added', { ascending: false });
 
       if (error) {
-        console.error('Error fetching loads:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to fetch loads. Please try again.'
+        });
         return;
       }
 
@@ -89,7 +99,11 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
         setLoads(formattedLoads);
       }
     } catch (error) {
-      console.error('Error fetching loads:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to fetch loads. Please try again.'
+      });
     }
   };
 
@@ -120,7 +134,11 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
           .single();
 
         if (error) {
-          console.error('Error adding load:', error);
+          toast({
+            variant: 'destructive',
+            title: 'Error',
+            description: 'Failed to add load. Please try again.'
+          });
           return;
         }
 
@@ -150,7 +168,11 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
           setShowAddForm(false);
         }
       } catch (error) {
-        console.error('Error adding load:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to add load. Please try again.'
+        });
       } finally {
         setLoading(false);
       }
@@ -166,13 +188,21 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
         .eq('user_id', user.id);
 
       if (error) {
-        console.error('Error deleting load:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to delete load. Please try again.'
+        });
         return;
       }
 
       setLoads(prev => prev.filter(load => load.id !== id));
     } catch (error) {
-      console.error('Error deleting load:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to delete load. Please try again.'
+      });
     }
   };
 
@@ -193,7 +223,11 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
         .eq('user_id', user.id);
 
       if (error) {
-        console.error('Error updating load:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to update load. Please try again.'
+        });
         return;
       }
 
@@ -202,7 +236,11 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
       ));
       setEditingLoad(null);
     } catch (error) {
-      console.error('Error updating load:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to update load. Please try again.'
+      });
     }
   };
 

--- a/src/hooks/useMileageManager.ts
+++ b/src/hooks/useMileageManager.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { WeeklyMileage } from '@/types/LoadReports';
+import { useToast } from '@/hooks/use-toast';
 
 export const useMileageManager = (user: any, weekStart: Date) => {
   const [weeklyMileage, setWeeklyMileage] = useState<WeeklyMileage>({
@@ -12,6 +13,7 @@ export const useMileageManager = (user: any, weekStart: Date) => {
   const isUserInputRef = useRef(false);
   const fetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const { toast } = useToast();
 
   const fetchWeeklyMileage = async () => {
     if (!user || isLoading) return;
@@ -28,7 +30,11 @@ export const useMileageManager = (user: any, weekStart: Date) => {
         .maybeSingle();
 
       if (error) {
-        console.error('Error fetching weekly mileage:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to fetch weekly mileage. Please try again.'
+        });
         return;
       }
 
@@ -46,7 +52,11 @@ export const useMileageManager = (user: any, weekStart: Date) => {
         });
       }
     } catch (error) {
-      console.error('Error fetching weekly mileage:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to fetch weekly mileage. Please try again.'
+      });
     } finally {
       setIsLoading(false);
     }
@@ -72,10 +82,18 @@ export const useMileageManager = (user: any, weekStart: Date) => {
         });
   
       if (error) {
-        console.error('Error saving weekly mileage:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to save weekly mileage. Please try again.'
+        });
       }
     } catch (error) {
-      console.error('Error saving weekly mileage:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to save weekly mileage. Please try again.'
+      });
     } finally {
       isUserInputRef.current = false;
     }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import { Truck, Calculator, Settings, DollarSign, FileText, LogOut, Receipt } fr
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
 import LoginPage from '@/components/LoginPage';
 import Registration from '@/components/Registration';
 import LoadReports from '@/components/LoadReports';
@@ -14,6 +15,7 @@ import PersonalExpenses from '@/components/PersonalExpenses';
 
 const Index = () => {
   const { user, loading, signOut } = useAuth();
+  const { toast } = useToast();
   const [currentView, setCurrentView] = useState('dashboard');
   const [showRegistration, setShowRegistration] = useState(false);
   const [userProfile, setUserProfile] = useState(null);
@@ -38,7 +40,11 @@ const Index = () => {
         .eq('is_fixed', true);
       
       if (error) {
-        console.error('Error fetching deductions:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Error',
+          description: 'Failed to fetch deductions. Please try again.'
+        });
         return;
       }
       
@@ -54,7 +60,11 @@ const Index = () => {
         setDeductions(mappedDeductions);
       }
     } catch (error) {
-      console.error('Error fetching deductions:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to fetch deductions. Please try again.'
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- use toast notifications for Supabase errors in hooks and components
- remove console.error usage in favor of user-facing toasts

## Testing
- `npm run lint` *(fails: Unexpected any and require style imports)*

------
https://chatgpt.com/codex/tasks/task_e_689c2c153f90833398ebb3e296a6d2b0