### PR TITLE
Add offline sync with service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,22 @@
+self.addEventListener('install', event => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open('truckpay-cache').then(cache => cache.add('/'))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});
+
+self.addEventListener('sync', event => {
+  if (event.tag === 'sync-queue') {
+    event.waitUntil(
+      self.clients.matchAll().then(clients => {
+        clients.forEach(client => client.postMessage('SYNC_QUEUE'));
+      })
+    );
+  }
+});

--- a/src/hooks/useDeductionsManager.ts
+++ b/src/hooks/useDeductionsManager.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { ExtraDeduction } from '@/types/LoadReports';
+import { useOfflineSync } from '@/hooks/useOfflineSync';
 
 /**
  * Хук управляет:
@@ -16,6 +17,63 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
   const [weeklyDeductions, setWeeklyDeductions] = useState<Record<string, string>>({});
   const [extraDeductionTypes, setExtraDeductionTypes] = useState<ExtraDeduction[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+
+  const { isOnline, queueAction, setCachedData, getCachedData } = useOfflineSync({
+    saveWeeklyDeduction: async (payload: any) => {
+      if (payload.delete) {
+        await supabase
+          .from('weekly_deductions')
+          .delete()
+          .eq('user_id', payload.user_id)
+          .eq('week_start', payload.week_start)
+          .eq('deduction_type', payload.deduction_type);
+      } else {
+        await supabase
+          .from('weekly_deductions')
+          .upsert(
+            {
+              user_id: payload.user_id,
+              week_start: payload.week_start,
+              deduction_type: payload.deduction_type,
+              amount: payload.amount,
+              updated_at: payload.updated_at,
+            },
+            { onConflict: 'user_id,week_start,deduction_type' },
+          );
+      }
+    },
+    saveExtraDeduction: async (payload: any) => {
+      const d = payload.deduction as ExtraDeduction;
+      if (d.id && !d.id.includes('_')) {
+        await supabase
+          .from('weekly_extra_deductions')
+          .update({
+            name: d.name,
+            amount: parseFloat(d.amount),
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', parseInt(d.id))
+          .eq('user_id', payload.user_id);
+      } else {
+        await supabase
+          .from('weekly_extra_deductions')
+          .insert({
+            user_id: payload.user_id,
+            week_start: payload.week_start,
+            name: d.name,
+            amount: parseFloat(d.amount),
+            date_added: d.dateAdded || new Date().toISOString(),
+          });
+      }
+    },
+    deleteExtraDeduction: async (payload: any) => {
+      await supabase
+        .from('weekly_extra_deductions')
+        .delete()
+        .eq('id', parseInt(payload.id))
+        .eq('user_id', payload.user_id);
+    }
+  });
 
   /** ---------- Helpers ---------- */
   const weekStartStr = weekStart.toISOString().slice(0, 10);
@@ -90,15 +148,35 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
   };
 
   const fetchAllDeductions = async () => {
-    // Fetch weekly deductions first and wait for completion
+    if (!user) return;
+    if (!isOnline) {
+      const cached = getCachedData('deductions', { weekly: {}, extra: [] });
+      setWeeklyDeductions(cached.weekly);
+      setExtraDeductionTypes(cached.extra);
+      return;
+    }
     await fetchWeeklyDeductions();
-    // Then fetch any extra deductions
     await fetchExtraDeductions();
   };
 
   /** ---------- Persistence ---------- */
   const saveWeeklyDeduction = async (type: string, amount: string) => {
     if (!user) return;
+
+    if (!isOnline) {
+      await queueAction({
+        type: 'saveWeeklyDeduction',
+        payload: {
+          user_id: user.id,
+          week_start: weekStartStr,
+          deduction_type: type,
+          amount: parseFloat(amount),
+          updated_at: new Date().toISOString(),
+          delete: !amount || parseFloat(amount) === 0
+        }
+      });
+      return;
+    }
 
     try {
       if (!amount || parseFloat(amount) === 0) {
@@ -129,6 +207,14 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
 
   const saveExtraDeduction = async (deduction: ExtraDeduction) => {
     if (!user) return false;
+
+    if (!isOnline) {
+      await queueAction({
+        type: 'saveExtraDeduction',
+        payload: { deduction, user_id: user.id, week_start: weekStartStr }
+      });
+      return true;
+    }
 
     try {
       if (deduction.id.includes('_')) {
@@ -172,6 +258,11 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
 
   const deleteExtraDeduction = async (id: string) => {
     if (!user || id.includes('_')) return; // temp-ID — запись ещё не создана
+
+    if (!isOnline) {
+      await queueAction({ type: 'deleteExtraDeduction', payload: { id, user_id: user.id } });
+      return;
+    }
 
     try {
       await supabase
@@ -246,6 +337,10 @@ export const useDeductionsManager = (user: any, weekStart: Date) => {
       extraAbortControllerRef.current?.abort();
     };
   }, [user?.id, weekStartStr]);                                       // <-- реагируем на смену недели
+
+  useEffect(() => {
+    setCachedData('deductions', { weekly: weeklyDeductions, extra: extraDeductionTypes });
+  }, [weeklyDeductions, extraDeductionTypes, setCachedData]);
 
   /** ---------- Totals ---------- */
   const totalWeeklyDeductions = Object.values(weeklyDeductions).reduce(

--- a/src/hooks/useLoadReports.ts
+++ b/src/hooks/useLoadReports.ts
@@ -3,6 +3,7 @@ import { format, addWeeks, subWeeks, isWithinInterval, parseISO } from 'date-fns
 import { supabase } from '@/integrations/supabase/client';
 import { getUserWeekStart, getUserWeekEnd } from '@/lib/weeklyPeriodUtils';
 import { Load, NewLoad, WeeklyMileage, ExtraDeduction } from '@/types/LoadReports';
+import { useOfflineSync } from '@/hooks/useOfflineSync';
 
 // Helper function to format dates without timezone issues
 const formatDateForDB = (date: Date): string => {
@@ -38,6 +39,26 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
     totalMiles: 0
   });
 
+  const { isOnline, queueAction, setCachedData, getCachedData } = useOfflineSync({
+    addLoad: async (payload: any) => {
+      await supabase.from('load_reports').insert(payload);
+    },
+    deleteLoad: async (payload: any) => {
+      await supabase
+        .from('load_reports')
+        .delete()
+        .eq('id', payload.id)
+        .eq('user_id', payload.user_id);
+    },
+    editLoad: async (payload: any) => {
+      await supabase
+        .from('load_reports')
+        .update(payload.updates)
+        .eq('id', payload.id)
+        .eq('user_id', payload.user_id);
+    }
+  });
+
   const weekStart = getUserWeekStart(currentWeek, userProfile);
   const weekEnd = getUserWeekEnd(currentWeek, userProfile);
 
@@ -59,7 +80,7 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
 
   const fetchLoads = async () => {
     if (!user) return;
-    
+
     try {
       const { data, error } = await supabase
         .from('load_reports')
@@ -85,8 +106,9 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
           dateAdded: load.date_added,
           weekPeriod: load.week_period
         }));
-        
+
         setLoads(formattedLoads);
+        setCachedData('loadReports', formattedLoads);
       }
     } catch (error) {
       console.error('Error fetching loads:', error);
@@ -96,59 +118,68 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
   const handleAddLoad = async () => {
     if (newLoad.rate && newLoad.companyDeduction && newLoad.locationFrom && newLoad.locationTo && user) {
       setLoading(true);
-      
+
       try {
         const driverPay = parseFloat(newLoad.rate) * (1 - parseFloat(newLoad.companyDeduction) / 100);
         const weekPeriod = `${format(weekStart, 'MMM dd')} - ${format(weekEnd, 'MMM dd, yyyy')}`;
         const loadDate = weekStart.toISOString().split('T')[0];
-        
-        const { data, error } = await supabase
-          .from('load_reports')
-          .insert({
-            user_id: user.id,
-            rate: parseFloat(newLoad.rate),
-            company_deduction: parseFloat(newLoad.companyDeduction),
-            driver_pay: driverPay,
-            location_from: newLoad.locationFrom,
-            location_to: newLoad.locationTo,
-            pickup_date: newLoad.pickupDate ? formatDateForDB(newLoad.pickupDate) : null,
-            delivery_date: newLoad.deliveryDate ? formatDateForDB(newLoad.deliveryDate) : null,
-            date_added: loadDate,
-            week_period: weekPeriod
-          })
-          .select()
-          .single();
 
-        if (error) {
-          console.error('Error adding load:', error);
-          return;
-        }
+        const payload = {
+          user_id: user.id,
+          rate: parseFloat(newLoad.rate),
+          company_deduction: parseFloat(newLoad.companyDeduction),
+          driver_pay: driverPay,
+          location_from: newLoad.locationFrom,
+          location_to: newLoad.locationTo,
+          pickup_date: newLoad.pickupDate ? formatDateForDB(newLoad.pickupDate) : null,
+          delivery_date: newLoad.deliveryDate ? formatDateForDB(newLoad.deliveryDate) : null,
+          date_added: loadDate,
+          week_period: weekPeriod
+        };
 
-        if (data) {
-          const newLoadEntry = {
-            id: data.id,
-            rate: data.rate,
-            companyDeduction: data.company_deduction,
-            driverPay: data.driver_pay,
-            locationFrom: data.location_from,
-            locationTo: data.location_to,
-            pickupDate: data.pickup_date,
-            deliveryDate: data.delivery_date,
-            dateAdded: data.date_added,
-            weekPeriod: data.week_period
-          };
-          
-          setLoads(prev => [...prev, newLoadEntry]);
-          setNewLoad({ 
-            rate: '', 
-            companyDeduction: userProfile?.companyDeduction || '',
-            locationFrom: '',
-            locationTo: '',
-            pickupDate: undefined,
-            deliveryDate: undefined
-          });
-          setShowAddForm(false);
-        }
+        const result = await queueAction({ type: 'addLoad', payload });
+
+        const newLoadEntry = result
+          ? {
+              id: result[0]?.id || result.id,
+              rate: result[0]?.rate ?? payload.rate,
+              companyDeduction: result[0]?.company_deduction ?? payload.company_deduction,
+              driverPay: result[0]?.driver_pay ?? payload.driver_pay,
+              locationFrom: result[0]?.location_from ?? payload.location_from,
+              locationTo: result[0]?.location_to ?? payload.location_to,
+              pickupDate: result[0]?.pickup_date ?? payload.pickup_date,
+              deliveryDate: result[0]?.delivery_date ?? payload.delivery_date,
+              dateAdded: result[0]?.date_added ?? payload.date_added,
+              weekPeriod: result[0]?.week_period ?? payload.week_period
+            }
+          : {
+              id: `temp_${Date.now()}`,
+              rate: payload.rate,
+              companyDeduction: payload.company_deduction,
+              driverPay: payload.driver_pay,
+              locationFrom: payload.location_from,
+              locationTo: payload.location_to,
+              pickupDate: payload.pickup_date,
+              deliveryDate: payload.delivery_date,
+              dateAdded: payload.date_added,
+              weekPeriod: payload.week_period
+            };
+
+        setLoads(prev => {
+          const updated = [...prev, newLoadEntry];
+          setCachedData('loadReports', updated);
+          return updated;
+        });
+
+        setNewLoad({
+          rate: '',
+          companyDeduction: userProfile?.companyDeduction || '',
+          locationFrom: '',
+          locationTo: '',
+          pickupDate: undefined,
+          deliveryDate: undefined
+        });
+        setShowAddForm(false);
       } catch (error) {
         console.error('Error adding load:', error);
       } finally {
@@ -159,18 +190,12 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
 
   const handleDeleteLoad = async (id: string) => {
     try {
-      const { error } = await supabase
-        .from('load_reports')
-        .delete()
-        .eq('id', id)
-        .eq('user_id', user.id);
-
-      if (error) {
-        console.error('Error deleting load:', error);
-        return;
-      }
-
-      setLoads(prev => prev.filter(load => load.id !== id));
+      await queueAction({ type: 'deleteLoad', payload: { id, user_id: user.id } });
+      setLoads(prev => {
+        const updated = prev.filter(load => load.id !== id);
+        setCachedData('loadReports', updated);
+        return updated;
+      });
     } catch (error) {
       console.error('Error deleting load:', error);
     }
@@ -178,28 +203,23 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
 
   const handleEditLoad = async (id: string, updatedLoad: Partial<Load>) => {
     try {
-      const { error } = await supabase
-        .from('load_reports')
-        .update({
-          rate: updatedLoad.rate,
-          company_deduction: updatedLoad.companyDeduction,
-          driver_pay: updatedLoad.driverPay,
-          location_from: updatedLoad.locationFrom,
-          location_to: updatedLoad.locationTo,
-          pickup_date: updatedLoad.pickupDate,
-          delivery_date: updatedLoad.deliveryDate
-        })
-        .eq('id', id)
-        .eq('user_id', user.id);
+      await queueAction({ type: 'editLoad', payload: { id, user_id: user.id, updates: {
+        rate: updatedLoad.rate,
+        company_deduction: updatedLoad.companyDeduction,
+        driver_pay: updatedLoad.driverPay,
+        location_from: updatedLoad.locationFrom,
+        location_to: updatedLoad.locationTo,
+        pickup_date: updatedLoad.pickupDate,
+        delivery_date: updatedLoad.deliveryDate
+      } } });
 
-      if (error) {
-        console.error('Error updating load:', error);
-        return;
-      }
-
-      setLoads(prev => prev.map(load => 
-        load.id === id ? { ...load, ...updatedLoad } : load
-      ));
+      setLoads(prev => {
+        const updated = prev.map(load =>
+          load.id === id ? { ...load, ...updatedLoad } : load
+        );
+        setCachedData('loadReports', updated);
+        return updated;
+      });
       setEditingLoad(null);
     } catch (error) {
       console.error('Error updating load:', error);
@@ -214,6 +234,16 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
     }
   };
 
+  useEffect(() => {
+    setWeeklyMileage(
+      getCachedData('weeklyMileage', { startMileage: '', endMileage: '', totalMiles: 0 })
+    );
+  }, [getCachedData]);
+
+  useEffect(() => {
+    setCachedData('weeklyMileage', weeklyMileage);
+  }, [weeklyMileage, setCachedData]);
+
   // Fetch all deduction types from database
   useEffect(() => {
     if (user) {
@@ -221,12 +251,16 @@ export const useLoadReports = (user: any, userProfile: any, deductions: any[]) =
     }
   }, [user]);
 
-  // Fetch loads and weekly deductions when week changes
+  // Fetch loads when week or connectivity changes
   useEffect(() => {
     if (user) {
-      fetchLoads();
+      if (isOnline) {
+        void fetchLoads();
+      } else {
+        setLoads(getCachedData('loadReports', []));
+      }
     }
-  }, [user, currentWeek]);
+  }, [user, currentWeek, isOnline, getCachedData]);
 
   const currentWeekLoads = loads
     .filter(load => {

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface OfflineAction {
+  type: string;
+  payload: any;
+}
+
+const QUEUE_KEY = 'offlineQueue';
+const CACHE_PREFIX = 'cache_';
+
+export const useOfflineSync = (
+  handlers: Record<string, (payload: any) => Promise<any>> = {}
+) => {
+  const [isOnline, setIsOnline] = useState(typeof navigator !== 'undefined' ? navigator.onLine : true);
+
+  const processQueue = useCallback(async () => {
+    const raw = localStorage.getItem(QUEUE_KEY);
+    const queue: OfflineAction[] = raw ? JSON.parse(raw) : [];
+    if (!queue.length) return;
+
+    const remaining: OfflineAction[] = [];
+    for (const action of queue) {
+      const handler = handlers[action.type];
+      if (handler) {
+        try {
+          await handler(action.payload);
+        } catch (err) {
+          console.error('Offline action failed', action, err);
+          remaining.push(action);
+        }
+      } else {
+        remaining.push(action);
+      }
+    }
+    localStorage.setItem(QUEUE_KEY, JSON.stringify(remaining));
+  }, [handlers]);
+
+  const queueAction = useCallback(
+    async (action: OfflineAction) => {
+      if (isOnline) {
+        const handler = handlers[action.type];
+        return handler ? handler(action.payload) : undefined;
+      } else {
+        const raw = localStorage.getItem(QUEUE_KEY);
+        const queue: OfflineAction[] = raw ? JSON.parse(raw) : [];
+        queue.push(action);
+        localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+        return undefined;
+      }
+    },
+    [isOnline, handlers]
+  );
+
+  const setCachedData = useCallback((key: string, data: any) => {
+    localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(data));
+  }, []);
+
+  const getCachedData = useCallback(<T,>(key: string, fallback: T): T => {
+    const raw = localStorage.getItem(CACHE_PREFIX + key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  }, []);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      setIsOnline(true);
+      void processQueue();
+      navigator.serviceWorker?.ready.then(reg => {
+        if ('sync' in reg) {
+          reg.sync.register('sync-queue').catch(console.error);
+        }
+      }).catch(() => {});
+    };
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    if (isOnline) {
+      void processQueue();
+    }
+
+    const messageHandler = (event: MessageEvent) => {
+      if (event.data === 'SYNC_QUEUE') {
+        void processQueue();
+      }
+    };
+    navigator.serviceWorker?.addEventListener('message', messageHandler);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+      navigator.serviceWorker?.removeEventListener('message', messageHandler);
+    };
+  }, [isOnline, processQueue]);
+
+  return { isOnline, queueAction, setCachedData, getCachedData };
+};
+
+export type UseOfflineSync = ReturnType<typeof useOfflineSync>;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,12 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById('root')!).render(<App />)
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(err => {
+      console.error('Service worker registration failed', err)
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- add `useOfflineSync` hook for caching and replaying actions when offline
- queue load report and deduction writes while offline
- register service worker for offline support and background sync

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 36 errors, 18 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c3325a3208333a176d5fdb61016ac